### PR TITLE
Exclude iron-flex-layout

### DIFF
--- a/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow/pom.xml
@@ -37,6 +37,10 @@
                     <groupId>org.webjars.bowergithub.vaadin</groupId>
                     <artifactId>vaadin-dialog</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.webjars.bowergithub.polymerelements</groupId>
+                    <artifactId>iron-flex-layout</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -118,6 +122,10 @@
         <dependency>
             <groupId>org.webjars.bowergithub.polymerelements</groupId>
             <artifactId>iron-resizable-behavior</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-flex-layout</artifactId>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
all other dependencies have this dependency excluded because
https://repo1.maven.org/maven2/org/webjars/bowergithub/polymerelements/iron-flex-layout/1.3.7/
has no .pom
(i.e. package is in the corrupt state).
It causes nexus plugin used in released builds to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-confirm-dialog-flow/48)
<!-- Reviewable:end -->
