### PR TITLE
Fix setWidth/setHeight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bower_components
 node
 yarn.lock
 .idea/
+.vscode/
 **.iml
 vaadin-confirm-dialog-integration-tests/error-screenshots/
 

--- a/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.vaadin.webjar</groupId>
             <artifactId>vaadin-confirm-dialog</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.vaadin.webjar</groupId>
             <artifactId>vaadin-confirm-dialog</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/vaadin-confirm-dialog-flow/pom.xml
+++ b/vaadin-confirm-dialog-flow/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.vaadin.webjar</groupId>
             <artifactId>vaadin-confirm-dialog</artifactId>
-            <version>1.1.3</version>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -584,16 +584,14 @@ public class ConfirmDialog extends Component
     }
 
     private void ensureAttached() {
-        if (getElement().getNode().getParent() == null) {
-            UI ui = getCurrentUI();
-            ui.beforeClientResponse(ui, context -> {
-                if (getElement().getNode().getParent() == null) {
-                    ui.add(this);
-                    autoAddedToTheUi = true;
-                    updateWidth();
-                    updateHeight();
-                }
-            });
-        }
+        UI ui = getCurrentUI();
+        ui.beforeClientResponse(ui, context -> {
+            if (getElement().getNode().getParent() == null) {
+                ui.add(this);
+                autoAddedToTheUi = true;
+                updateWidth();
+                updateHeight();
+            }
+        });
     }
 }

--- a/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -78,6 +78,53 @@ public class ConfirmDialog extends Component
         }
     }
 
+    private String height;
+    private String width;
+
+    /**
+     * Sets the width of the component content area.
+     * <p>
+     * The width should be in a format understood by the browser, e.g. "100px"
+     * or "2.5em" (Using relative unit, such as percentage, will lead to unexpected results).
+     * <p>
+     * If the provided {@code width} value is {@literal null} then width is
+     * removed.
+     *
+     * @param width
+     *            the width to set, may be {@code null}
+     */
+    @Override
+    public void setWidth(String width) {
+        this.width = width;
+        updateWidth();
+    }
+
+    private void updateWidth() {
+        this.getElement().executeJs("this._setWidth($0)", this.width);
+    }
+
+    /**
+     * Sets the height of the component content area.
+     * <p>
+     * The height should be in a format understood by the browser, e.g. "100px"
+     * or "2.5em" (Using relative unit, such as percentage, will lead to unexpected results).
+     * <p>
+     * If the provided {@code height} value is {@literal null} then height is
+     * removed.
+     *
+     * @param height
+     *            the height to set, may be {@code null}
+     */
+    @Override
+    public void setHeight(String height) {
+        this.height = height;
+        updateHeight();
+    }
+
+    public void updateHeight() {
+        this.getElement().executeJs("this._setHeight($0)", this.height);
+    }
+
     private boolean autoAddedToTheUi;
 
     /**
@@ -542,6 +589,8 @@ public class ConfirmDialog extends Component
             ui.beforeClientResponse(ui, context -> {
                 ui.add(this);
                 autoAddedToTheUi = true;
+                updateWidth();
+                updateHeight();
             });
         }
     }

--- a/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -40,7 +40,7 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-confirm-dialog")
-@NpmPackage(value="@vaadin/vaadin-confirm-dialog", version = "1.1.2")
+@NpmPackage(value="@vaadin/vaadin-confirm-dialog", version = "1.1.3")
 @JsModule("@vaadin/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js")
 @HtmlImport("frontend://bower_components/vaadin-confirm-dialog/src/vaadin-confirm-dialog.html")
 public class ConfirmDialog extends Component

--- a/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -40,7 +40,7 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-confirm-dialog")
-@NpmPackage(value="@vaadin/vaadin-confirm-dialog", version = "1.1.1")
+@NpmPackage(value="@vaadin/vaadin-confirm-dialog", version = "1.1.2")
 @JsModule("@vaadin/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js")
 @HtmlImport("frontend://bower_components/vaadin-confirm-dialog/src/vaadin-confirm-dialog.html")
 public class ConfirmDialog extends Component
@@ -587,10 +587,12 @@ public class ConfirmDialog extends Component
         if (getElement().getNode().getParent() == null) {
             UI ui = getCurrentUI();
             ui.beforeClientResponse(ui, context -> {
-                ui.add(this);
-                autoAddedToTheUi = true;
-                updateWidth();
-                updateHeight();
+                if (getElement().getNode().getParent() == null) {
+                    ui.add(this);
+                    autoAddedToTheUi = true;
+                    updateWidth();
+                    updateHeight();
+                }
             });
         }
     }

--- a/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
+++ b/vaadin-confirm-dialog-flow/src/main/java/com/vaadin/flow/component/confirmdialog/ConfirmDialog.java
@@ -40,7 +40,7 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vaadin-confirm-dialog")
-@NpmPackage(value="@vaadin/vaadin-confirm-dialog", version = "1.1.3")
+@NpmPackage(value="@vaadin/vaadin-confirm-dialog", version = "1.1.4")
 @JsModule("@vaadin/vaadin-confirm-dialog/src/vaadin-confirm-dialog.js")
 @HtmlImport("frontend://bower_components/vaadin-confirm-dialog/src/vaadin-confirm-dialog.html")
 public class ConfirmDialog extends Component

--- a/vaadin-confirm-dialog-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/Dimensions.java
+++ b/vaadin-confirm-dialog-integration-tests/src/main/java/com/vaadin/flow/component/confirmdialog/examples/Dimensions.java
@@ -1,0 +1,70 @@
+package com.vaadin.flow.component.confirmdialog.examples;
+
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.page.BodySize;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Dimensions
+ */
+@Route("Dimensions")
+@BodySize
+public class Dimensions extends Div {
+
+    public static String CONFIRM_DIALOG_ID = "confirm-dialog-dimensions";
+    public static String OPEN_DIALOG_ID = "open-confirm-dialog-id";
+    public static String ATTACH_DIALOG_ID = "attach-confirm-dialog";
+    public static String CHANGE_DIALOG_WIDTH_ID = "change-confirm-dialog-width";
+    public static String CHANGE_DIALOG_HEIGHT_ID = "change-confirm-dialog-height";
+    public static String CHANGE_DIALOG_ATTACHED_WIDTH_ID = "change-confirm-attached-dialog-width";
+    public static String CHANGE_DIALOG_ATTACHED_HEIGHT_ID = "change-confirm-attached-dialog-height";
+    public static String RESET_DIALOG_DIMENSIONS_ID = "reset-confirm-dialog-dimensions";
+
+    public static String DIMENSION_BIGGER = "600px";
+    public static String DIMENSION_SMALLER = "300px";
+
+    public Dimensions() {
+        ConfirmDialog confirmDialog = new ConfirmDialog();
+        confirmDialog.setId(CONFIRM_DIALOG_ID);
+        confirmDialog.setHeader("Confirm dialog header");
+
+        Button changeWidthOpenedButton = new Button("ChangeWidth", e -> confirmDialog.setWidth(DIMENSION_SMALLER));
+        changeWidthOpenedButton.setId(CHANGE_DIALOG_ATTACHED_WIDTH_ID);
+
+        Button changeHeightOpenedButton = new Button("ChangeHeight", e -> confirmDialog.setHeight(DIMENSION_SMALLER));
+        changeHeightOpenedButton.setId(CHANGE_DIALOG_ATTACHED_HEIGHT_ID);
+
+        confirmDialog.add(changeWidthOpenedButton, changeHeightOpenedButton);
+
+        Button attachConfirmDialogButton = new Button("AttachConfirmDialog", e -> {
+            add(confirmDialog);
+        });
+        attachConfirmDialogButton.setId(ATTACH_DIALOG_ID);
+
+        Button openConfirmDialogButton = new Button("OpenConfirmDialog", e -> {
+            confirmDialog.open();
+        });
+        openConfirmDialogButton.setId(OPEN_DIALOG_ID);
+
+        Button changeDialogWidthButton = new Button("ChangeDialogWidth", e -> {
+            confirmDialog.setWidth(DIMENSION_BIGGER);
+        });
+        changeDialogWidthButton.setId(CHANGE_DIALOG_WIDTH_ID);
+
+        Button changeDialogHeightButton = new Button("ChangeDialogHeight", e -> {
+            confirmDialog.setHeight(DIMENSION_BIGGER);
+        });
+        changeDialogHeightButton.setId(CHANGE_DIALOG_HEIGHT_ID);
+
+        Button resetDialogDimenssion = new Button("ResetDialogDimensions", e -> {
+            confirmDialog.setWidth(null);
+            confirmDialog.setHeight(null);
+        });
+        resetDialogDimenssion.setId(RESET_DIALOG_DIMENSIONS_ID);
+
+        add(attachConfirmDialogButton, openConfirmDialogButton, changeDialogWidthButton, changeDialogHeightButton,
+                resetDialogDimenssion);
+    }
+}

--- a/vaadin-confirm-dialog-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/DimensionsIT.java
+++ b/vaadin-confirm-dialog-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/DimensionsIT.java
@@ -1,0 +1,147 @@
+package com.vaadin.flow.component.confirmdialog.test;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.confirmdialog.examples.Dimensions;
+import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.annotations.RunLocally;
+import com.vaadin.testbench.parallel.Browser;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * DimensionsIT
+ */
+@RunLocally(Browser.CHROME)
+public class DimensionsIT extends AbstractParallelTest {
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        System.setProperty("webdriver.chrome.driver", "/Users/diegocardoso/Tools/chromedriver");
+        getDriver().manage().window().setSize(WINDOW_SIZE_MEDIUM);
+    }
+
+    @Before
+    public void init() {
+        getDriver().get(getBaseURL() + "/Dimensions");
+    }
+
+    @Test
+    public void testWidthCanChange() {
+        changeDialogWidth();
+        openDialog();
+
+        String width = getCssContentValue("width");
+
+        Assert.assertEquals(Dimensions.DIMENSION_BIGGER, width);
+    }
+
+    @Test
+    public void testHeightCanChange() {
+        changeDialogHeight();
+        openDialog();
+
+        String height = getCssContentValue("height");
+
+        Assert.assertEquals(Dimensions.DIMENSION_BIGGER, height);
+    }
+
+    @Test
+    public void testChangeDimensionOnAttachedDialod() {
+        attachDialog();
+        changeDialogWidth();
+        changeDialogHeight();
+        openDialog();
+
+        Assert.assertEquals(Dimensions.DIMENSION_BIGGER, getCssContentValue("height"));
+        Assert.assertEquals(Dimensions.DIMENSION_BIGGER, getCssContentValue("width"));
+    }
+
+    @Test
+    public void testDimensionsChangeAreKeptAfterClosingAndOpening() {
+        changeDialogHeight();
+        openDialog();
+
+        String height = getCssContentValue("height");
+
+        Assert.assertEquals(Dimensions.DIMENSION_BIGGER, height);
+
+        getConfirmDialog().getConfirmButton().click();
+
+        openDialog();
+
+        height = getCssContentValue("height");
+
+        Assert.assertEquals(Dimensions.DIMENSION_BIGGER, height);
+    }
+
+    @Test
+    public void testDimensionsCanBeReset() {
+        openDialog();
+
+        String originalHeight = getCssContentValue("height");
+        String originalWidth = getCssContentValue("width");
+
+        getConfirmDialog().getConfirmButton().click();
+
+        changeDialogWidth();
+        changeDialogHeight();
+
+        openDialog();
+        getConfirmDialog().getConfirmButton().click();
+        resetDimensions();
+        openDialog();
+
+        Assert.assertEquals(originalHeight, getCssContentValue("height"));
+        Assert.assertEquals(originalWidth, getCssContentValue("width"));
+    }
+
+    @Test
+    public void testChangeOpenedDialogDimensions() {
+        openDialog();
+
+        ConfirmDialogElement confirmDialog = getConfirmDialog();
+
+        confirmDialog.$(ButtonElement.class).id(Dimensions.CHANGE_DIALOG_ATTACHED_WIDTH_ID).click();
+        confirmDialog.$(ButtonElement.class).id(Dimensions.CHANGE_DIALOG_ATTACHED_HEIGHT_ID).click();
+
+        waitUntil(driver -> Dimensions.DIMENSION_SMALLER.equals(getCssContentValue("height"))
+                && Dimensions.DIMENSION_SMALLER.equals(getCssContentValue("width")));
+    }
+
+    private ConfirmDialogElement getConfirmDialog() {
+        return $(ConfirmDialogElement.class).waitForFirst();
+    }
+
+    private String getCssContentValue(String value) {
+        return getContent().getCssValue(value);
+    }
+
+    private TestBenchElement getContent() {
+        return getConfirmDialog().$("div[part=content]").first();
+    }
+
+    private void attachDialog() {
+        $(ButtonElement.class).id(Dimensions.ATTACH_DIALOG_ID).click();
+    }
+
+    private void openDialog() {
+        $(ButtonElement.class).id(Dimensions.OPEN_DIALOG_ID).click();
+    }
+
+    private void changeDialogWidth() {
+        $(ButtonElement.class).id(Dimensions.CHANGE_DIALOG_WIDTH_ID).click();
+    }
+
+    private void changeDialogHeight() {
+        $(ButtonElement.class).id(Dimensions.CHANGE_DIALOG_HEIGHT_ID).click();
+    }
+
+    private void resetDimensions() {
+        $(ButtonElement.class).id(Dimensions.RESET_DIALOG_DIMENSIONS_ID).click();
+    }
+
+}

--- a/vaadin-confirm-dialog-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/DimensionsIT.java
+++ b/vaadin-confirm-dialog-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/DimensionsIT.java
@@ -62,9 +62,7 @@ public class DimensionsIT extends AbstractParallelTest {
 
         openDialog();
 
-        height = getCssContentValue("height");
-
-        Assert.assertEquals(Dimensions.DIMENSION_BIGGER, height);
+        waitUntil(driver -> Dimensions.DIMENSION_BIGGER.equals(getCssContentValue("height")));
     }
 
     @Test
@@ -110,7 +108,7 @@ public class DimensionsIT extends AbstractParallelTest {
     }
 
     private TestBenchElement getContent() {
-        return getConfirmDialog().$("div[part=content]").first();
+        return ((TestBenchElement) getConfirmDialog().getContext());
     }
 
     private void attachDialog() {

--- a/vaadin-confirm-dialog-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/DimensionsIT.java
+++ b/vaadin-confirm-dialog-integration-tests/src/test/java/com/vaadin/flow/component/confirmdialog/test/DimensionsIT.java
@@ -4,9 +4,6 @@ import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.confirmdialog.examples.Dimensions;
 import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
 import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.annotations.RunLocally;
-import com.vaadin.testbench.parallel.Browser;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,15 +11,7 @@ import org.junit.Test;
 /**
  * DimensionsIT
  */
-@RunLocally(Browser.CHROME)
 public class DimensionsIT extends AbstractParallelTest {
-
-    @Override
-    public void setup() throws Exception {
-        super.setup();
-        System.setProperty("webdriver.chrome.driver", "/Users/diegocardoso/Tools/chromedriver");
-        getDriver().manage().window().setSize(WINDOW_SIZE_MEDIUM);
-    }
 
     @Before
     public void init() {
@@ -50,7 +39,7 @@ public class DimensionsIT extends AbstractParallelTest {
     }
 
     @Test
-    public void testChangeDimensionOnAttachedDialod() {
+    public void testChangeDimensionOnAttachedDialog() {
         attachDialog();
         changeDialogWidth();
         changeDialogHeight();


### PR DESCRIPTION
Use `vaadin-confirm-dialog` internal API to set content width and height.

Fixes #40

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-confirm-dialog-flow/89)
<!-- Reviewable:end -->
